### PR TITLE
Add missing props and CSS class prefix to components

### DIFF
--- a/.templates/component/{{ pascalCase name }}.scss.txt
+++ b/.templates/component/{{ pascalCase name }}.scss.txt
@@ -1,3 +1,3 @@
 @use '@/styles/global.scss' as global;
 
-.{{ kebabCase name }} {}
+.cmp-{{ kebabCase name }} {}

--- a/.templates/component/{{ pascalCase name }}.tsx.txt
+++ b/.templates/component/{{ pascalCase name }}.tsx.txt
@@ -7,5 +7,10 @@ import { className } from '@/utils/component/class-name';
 import './{{ pascalCase name }}.scss';
 
 export const {{ pascalCase name }} = (props: {{ pascalCase name }}Props): ReactElement => {
-	return <div {...getAbstractProps(props)} {...className('{{ kebabCase name }}')}></div>;
+	return (
+		<div
+			{...getAbstractProps(props)}
+			{...className('cmp-{{ kebabCase name }}', props.className)}
+		></div>
+	);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gincat-digital-react-skeleton",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "author": "Braian Rosas <brdevok@outlook.com> (https://github.com/brdevok)",
   "license": "MIT",
   "scripts": {

--- a/src/components/heading/hello-world/HelloWorld.scss
+++ b/src/components/heading/hello-world/HelloWorld.scss
@@ -1,5 +1,5 @@
 @use '@/styles/global.scss' as global;
 
-.hello-world {
+.cmp-hello-world {
 	color: global.$primaryColor;
 }

--- a/src/components/heading/hello-world/HelloWorld.tsx
+++ b/src/components/heading/hello-world/HelloWorld.tsx
@@ -13,7 +13,10 @@ export const HelloWorld = (props: HelloWorldProps): ReactElement => {
 	const { t } = useTranslation(LocalesNS.Global);
 
 	return (
-		<h1 {...getAbstractProps(props)} {...className('hello-world')}>
+		<h1
+			{...getAbstractProps(props)}
+			{...className('cmp-hello-world', props.className)}
+		>
 			{t(globalLocales.helloWorld, { name: props.name })}
 		</h1>
 	);


### PR DESCRIPTION
Add `cmp` prefix to component class and pass `props.className` to `className` util.