### PR TITLE
Expand argTypes categories and fix plop templates imports

### DIFF
--- a/.templates/component/{{ pascalCase name }}.tsx.txt
+++ b/.templates/component/{{ pascalCase name }}.tsx.txt
@@ -2,8 +2,8 @@ import type { ReactElement } from 'react';
 import type { {{ pascalCase name }}Props } from './{{ pascalCase name }}.types';
 import React from 'react';
 import { BEM } from '@/utils/bem/BEM';
-import { getAbstractProps } from '@/utils/component/get-abstract-props';
-import { className } from '@/utils/component/class-name';
+import { getAbstractProps } from '@/utils/component/getAbstractProps';
+import { className } from '@/utils/component/className';
 
 import './{{ pascalCase name }}.scss';
 

--- a/src/storybook/argTypes.types.ts
+++ b/src/storybook/argTypes.types.ts
@@ -4,4 +4,5 @@ export type Category =
 	| 'accesibility'
 	| 'action'
 	| 'state'
+	| 'template'
 	| 'other';


### PR DESCRIPTION
- Add 'template' to Category type in argTypes utils.
- Fix outdated import names in plop templates.